### PR TITLE
Implement ULID.parse()

### DIFF
--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -254,4 +254,6 @@ def test_pydantic_protocol() -> None:
     } in model_json_schema["properties"]["ulid"]["anyOf"]
     assert {
         "type": "null",
-    } in model_json_schema["properties"]["ulid"]["anyOf"]
+    } in model_json_schema["properties"][
+        "ulid"
+    ]["anyOf"]

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -99,6 +99,17 @@ def test_idempotency() -> None:
     assert ULID.from_uuid(ulid.to_uuid()) == ulid
     assert ULID.from_int(int(ulid)) == ulid
     assert ULID.from_hex(ulid.hex) == ulid
+    assert ULID.parse(ulid) == ulid
+    assert ULID.parse(ulid.to_uuid()) == ulid
+    assert ULID.parse(str(ulid.to_uuid())) == ulid
+    assert ULID.parse(ulid.to_uuid().hex) == ulid
+    assert ULID.parse(str(ulid)) == ulid
+    assert ULID.parse(ulid.hex) == ulid
+    assert ULID.parse(ulid.to_uuid().int) == ulid
+    assert ULID.parse(ulid.milliseconds).milliseconds == ulid.milliseconds
+    assert ULID.parse(ulid.timestamp).timestamp == ulid.timestamp
+    assert ULID.parse(ulid.datetime).datetime == ulid.datetime
+    assert ULID.parse(ulid.bytes) == ulid
 
 
 def test_to_uuid4() -> None:
@@ -160,10 +171,12 @@ Params = Union[bytes, str, int, float]
         (ULID.from_str, "Z" * 26),  # invalid timestamp
         (ULID.from_int, "not-an-int"),  # invalid type
         (ULID.from_uuid, "not-a-uuid"),  # invalid type
+        (ULID.parse, "not-a-uuid"),  # invalid length
+        (ULID.parse, []),  # invalid type
     ],
 )
 def test_ulid_invalid_input(constructor: Callable[[Params], ULID], value: Params) -> None:
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises((ValueError, TypeError)):
         constructor(value)
 
 

--- a/ulid/__init__.py
+++ b/ulid/__init__.py
@@ -43,7 +43,7 @@ class validate_type(Generic[T]):  # noqa: N801
             if not isinstance(value, self.types):
                 message = "Value has to be of type "
                 message += " or ".join([t.__name__ for t in self.types])
-                raise TypeError(message)
+                raise ValueError(message)
             return func(cls, value)
 
         return wrapped
@@ -187,7 +187,7 @@ class ULID:
             return cls.from_datetime(value)
         if isinstance(value, bytes):
             return cls.from_bytes(value)
-        raise ValueError(f"Cannot parse ULID from type {type(value)}")
+        raise TypeError(f"Cannot parse ULID from type {type(value)}")
 
     @property
     def milliseconds(self) -> int:

--- a/ulid/__init__.py
+++ b/ulid/__init__.py
@@ -43,7 +43,7 @@ class validate_type(Generic[T]):  # noqa: N801
             if not isinstance(value, self.types):
                 message = "Value has to be of type "
                 message += " or ".join([t.__name__ for t in self.types])
-                raise ValueError(message)
+                raise TypeError(message)
             return func(cls, value)
 
         return wrapped


### PR DESCRIPTION
The package [`ulid-py`](https://github.com/ahawker/ulid) has the classmethod [`parse`](https://github.com/ahawker/ulid/blob/master/ulid/api/api.py#L64), used when the caller is trying to parse a ULID from a value when they're unsure what format/primitive type it will be given in.

This PR implements ULID.parse() for this package and according to its API.