### PR TITLE
fix: pydantic regex

### DIFF
--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -243,7 +243,7 @@ def test_pydantic_protocol() -> None:
     assert {
         "maxLength": 26,
         "minLength": 26,
-        "pattern": "[A-Z0-9]{26}",
+        "pattern": "[01234567][0123456789ABCDEFGHJKMNPQRSTVWXYZ]{25}",
         "type": "string",
     } in model_json_schema["properties"]["ulid"]["anyOf"]
     assert {

--- a/ulid/__init__.py
+++ b/ulid/__init__.py
@@ -297,7 +297,7 @@ class ULID:
             core_schema.union_schema([
                 core_schema.is_instance_schema(ULID),
                 core_schema.no_info_plain_validator_function(ULID),
-                core_schema.str_schema(pattern=r"[A-Z0-9]{26}", min_length=26, max_length=26),
+                core_schema.str_schema(pattern=r"[01234567][0123456789ABCDEFGHJKMNPQRSTVWXYZ]{25}", min_length=26, max_length=26),
                 core_schema.bytes_schema(min_length=16, max_length=16),
             ]),
             serialization=core_schema.to_string_ser_schema(


### PR DESCRIPTION
Fixes #42 .

1. First character should be `[0-7]`
https://github.com/mdomke/python-ulid/blob/df6b91d713eee0083e72221b344a32492c72fe9d/ulid/base32.py#L210

2. The character set is `[0123456789ABCDEFGHJKMNPQRSTVWXYZ]`

https://github.com/mdomke/python-ulid/blob/df6b91d713eee0083e72221b344a32492c72fe9d/ulid/base32.py#L9