### PR TITLE
Fix generating monotonic ULIDs in the same ms

### DIFF
--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -74,6 +74,14 @@ def test_same_millisecond_overflow() -> None:
         ULID()
 
 
+def test_same_millisecond_monotonic_sorting_without_frozen_time() -> None:
+    previous_ulid = "" 
+    for i in range(10000):
+        new_ulid = ULID()
+        assert new_ulid > previous_ulid
+        previous_ulid = new_ulid
+
+
 def assert_sorted(seq: list) -> None:
     last = seq[0]
     for item in seq[1:]:

--- a/ulid/__init__.py
+++ b/ulid/__init__.py
@@ -69,10 +69,9 @@ class ValueProvider:
             raise ValueError("Value exceeds maximum possible timestamp")
         return value
 
-    def randomness(self) -> bytes:
+    def randomness(self, timestamp: int) -> bytes:
         with self.lock:
-            current_timestamp = self.timestamp()
-            if current_timestamp == self.prev_timestamp:
+            if timestamp == self.prev_timestamp:
                 if self.prev_randomness == constants.MAX_RANDOMNESS:
                     raise ValueError("Randomness within same millisecond exhausted")
                 randomness = self.increment_bytes(self.prev_randomness)
@@ -80,7 +79,7 @@ class ValueProvider:
                 randomness = os.urandom(constants.RANDOMNESS_LEN)
 
             self.prev_randomness = randomness
-            self.prev_timestamp = current_timestamp
+            self.prev_timestamp = timestamp
         return randomness
 
     def increment_bytes(self, value: bytes) -> bytes:
@@ -148,8 +147,9 @@ class ULID:
             >>> ULID.from_timestamp(time.time())
             ULID(01E75QWN5HKQ0JAVX9FG1K4YP4)
         """
-        timestamp = int.to_bytes(cls.provider.timestamp(value), constants.TIMESTAMP_LEN, "big")
-        randomness = cls.provider.randomness()
+        timestamp_value = cls.provider.timestamp(value)
+        timestamp = int.to_bytes(timestamp_value, constants.TIMESTAMP_LEN, "big")
+        randomness = cls.provider.randomness(timestamp_value)
         return cls.from_bytes(timestamp + randomness)
 
     @classmethod


### PR DESCRIPTION
Due to a race condition, the intended behaviour to provide monotonic incrementing ULID values, even when they are generated during the same timestamp in milliseconds, is not reliable.

This patch fixes the issue.
For more information, see the issue report at:

https://github.com/mdomke/python-ulid/issues/45