### PR TITLE
Update pyproject and uv lock to fix missing `typing_extensions` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
+dependencies = [
+    "typing-extensions",
+]
 
 [project.urls]
 Homepage = "https://github.com/mdomke/python-ulid"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -825,6 +825,9 @@ wheels = [
 [[package]]
 name = "python-ulid"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions" },
+]
 
 [package.optional-dependencies]
 pydantic = [
@@ -841,7 +844,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.0" }]
+requires-dist = [
+    { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.0" },
+    { name = "typing-extensions" },
+]
 provides-extras = ["pydantic"]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
# Fix missing `typing_extensions` dependency

This PR updates `pyproject.toml` and `uv.lock` to explicitly include `typing_extensions` as a dependency.

## Changes
- Added `typing_extensions` to project dependencies in `pyproject.toml`
- Updated `uv.lock` to reflect the new dependency

## Motivation
The `typing_extensions` package was being used in the codebase but not explicitly declared as a dependency, which could lead to import errors in certain environments where it's not already installed as a transitive dependency.

This ensures the package will work reliably across all Python versions and installation scenarios.