### PR TITLE
Fix a warning from UV

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,10 +105,10 @@ source = ["ulid"]
 [tool.doc8]
 max-line-length = 100
 
-[tool.uv]
-dev-dependencies = [
-    "hatch>=1.14.1",
+[dependency-groups]
+dev = [
     "freezegun>=1.5",
+    "hatch>=1.14.1",
     "sphinx>=7.4.7",
 ]
 


### PR DESCRIPTION
> warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`)
> is deprecated and will be removed in a future release;
> use `dependency-groups.dev` instead
