### PR TITLE
Depend on typing-extensions for Python<3.11; avoid it otherwise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
+dependencies = [
+    "typing-extensions; python_version < '3.11'",
+]
 
 [project.urls]
 Homepage = "https://github.com/mdomke/python-ulid"

--- a/ulid/__init__.py
+++ b/ulid/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import os
-import sys
 import time
 import uuid
 from datetime import datetime
@@ -14,22 +13,22 @@ from typing import Generic
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
 from ulid import base32
 from ulid import constants
 
 
 if TYPE_CHECKING:  # pragma: no cover
+    import sys
     from collections.abc import Callable
 
     from pydantic import GetCoreSchemaHandler
     from pydantic import ValidatorFunctionWrapHandler
     from pydantic_core import CoreSchema
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 try:
     from importlib.metadata import version
@@ -204,7 +203,7 @@ class ULID:
             a value when they're unsure what format/primitive type it will be given in.
         """
         if isinstance(value, ULID):
-            return cast(Self, value)
+            return cast("Self", value)
         if isinstance(value, uuid.UUID):
             return cls.from_uuid(value)
         if isinstance(value, str):

--- a/ulid/__init__.py
+++ b/ulid/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import os
+import sys
 import time
 import uuid
 from datetime import datetime
@@ -13,7 +14,11 @@ from typing import Generic
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
-from typing_extensions import Self
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from ulid import base32
 from ulid import constants

--- a/uv.lock
+++ b/uv.lock
@@ -825,6 +825,9 @@ wheels = [
 [[package]]
 name = "python-ulid"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
 
 [package.optional-dependencies]
 pydantic = [
@@ -841,7 +844,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.0" }]
+requires-dist = [
+    { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
 provides-extras = ["pydantic"]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Conditionalize the import of `typing_extensions`, needed only in Python 3.10 and older; use `typing` instead for Python 3.11 and later. Add a dependency on `typing-extensions`, appropriately conditioned on the Python interpreter version.

Based on https://github.com/mdomke/python-ulid/pull/47 and https://github.com/mdomke/python-ulid/pull/47#issuecomment-3431221960.

Fixes https://github.com/mdomke/python-ulid/issues/44.