### PR TITLE
fix: prevent non-monotonic ULIDs from timestamp/randomness clock skew

### DIFF
--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -67,8 +67,21 @@ def test_same_millisecond_monotonic_sorting() -> None:
     assert_sorted(ulids)
 
 
+def test_z_real_time_monotonic_sorting() -> None:
+    """ULIDs generated in rapid succession must be monotonically increasing.
+
+    This catches the bug where ``from_timestamp()`` samples the clock twice,
+    potentially crossing a millisecond boundary between the timestamp capture
+    and the randomness generation, which could produce a fresh (smaller) random
+    value instead of incrementing the previous one.
+    """
+    ulids = [ULID() for _ in range(5000)]
+    assert_sorted(ulids)
+
+
 @freeze_time()
 def test_same_millisecond_overflow() -> None:
+    ULID.provider.prev_timestamp = ULID.provider.timestamp()
     ULID.provider.prev_randomness = constants.MAX_RANDOMNESS
     with pytest.raises(ValueError, match="Randomness within same millisecond exhausted"):
         ULID()

--- a/ulid/__init__.py
+++ b/ulid/__init__.py
@@ -69,9 +69,10 @@ class ValueProvider:
             raise ValueError("Value exceeds maximum possible timestamp")
         return value
 
-    def randomness(self) -> bytes:
+    def randomness(self, current_timestamp: int | None = None) -> bytes:
         with self.lock:
-            current_timestamp = self.timestamp()
+            if current_timestamp is None:
+                current_timestamp = self.timestamp()
             if current_timestamp == self.prev_timestamp:
                 if self.prev_randomness == constants.MAX_RANDOMNESS:
                     raise ValueError("Randomness within same millisecond exhausted")
@@ -148,8 +149,9 @@ class ULID:
             >>> ULID.from_timestamp(time.time())
             ULID(01E75QWN5HKQ0JAVX9FG1K4YP4)
         """
-        timestamp = int.to_bytes(cls.provider.timestamp(value), constants.TIMESTAMP_LEN, "big")
-        randomness = cls.provider.randomness()
+        timestamp_value = cls.provider.timestamp(value)
+        timestamp = int.to_bytes(timestamp_value, constants.TIMESTAMP_LEN, "big")
+        randomness = cls.provider.randomness(timestamp_value)
         return cls.from_bytes(timestamp + randomness)
 
     @classmethod


### PR DESCRIPTION
## Problem

`from_timestamp()` samples the system clock twice: once for the timestamp value and again inside `randomness()` to decide whether to increment or generate fresh entropy. When a millisecond boundary falls between these two samples, the encoded ULID carries the **old** timestamp but **fresh** (potentially much smaller) randomness, breaking the lexicographic sort-order guarantee within the same millisecond.

Seen in the wild:
```
prev=01KT6JE36AYQD46B7SP5T0K6K9  ts=01KT6JE36A rand=YQD46B7SP5T0K6K9
curr=01KT6JE36A9KNN12R9RC3JDJK0  ts=01KT6JE36A rand=9KNN12R9RC3JDJK0
```
Both have timestamp `01KT6JE36A` but the randomness dropped from `Y...` to `9...`.

## Fix

Pass the **same** resolved timestamp from `from_timestamp()` into `randomness()` as an optional parameter, so the timestamp used for the ULID bytes and the monotonicity decision are guaranteed identical. The parameter defaults to `None` (backward-compatible), preserving existing callers.

- `ulid/__init__.py`: `randomness()` accepts optional `current_timestamp`; `from_timestamp()` captures the resolved value and passes it through (+6 / -4 lines).
- `tests/test_ulid.py`: added `test_z_real_time_monotonic_sorting()` generating 5000 ULIDs without frozen time (the exact scenario that triggers the bug), and made the overflow test self-contained.

Tested with the reproduction from issue #56 — zero violations over 100000 iterations.

This pull request was prepared with the assistance of AI, under my direction and review.

Fixes #56
Fixes #45